### PR TITLE
Select value fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ var selectedValue = ["bar", "buzz"]
 
 will select both values `"bar"` and `"buzz"`.
 
-NOTE: Changing `selectedValue` will overwrite any previous selections. However, changing `selectedValue` to be undefined, or a value that can be evaluated to be equal to the previous value (using lodash's `isEqual` function) will not cause values to be overwritten.
+NOTE: Changing `selectedValue` will overwrite any previous selections. However, changing `selectedValue` to be undefined, or a value that can be evaluated to be equal to the previous value (using lodash's `isEqual` function) will not cause values to be overwritten. Setting `selectedValue` to `null` will clear the selection.
 
 ##Contributing
 This following outlines the details of collaborating on this Ember addon:

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -391,7 +391,11 @@ export default Ember.Component.extend({
     let selected = index === null ? [] : [index]
     let values = this.getValues(selected)
     this.set('selected', selected)
-    this.closeList()
+
+    if (this.get('open')) {
+      this.closeList()
+    }
+
     if (this.get('on-change') && _.isFunction(this.get('on-change'))) {
       this.get('on-change')(values)
     }

--- a/tests/dummy/app/pods/demo/controller.js
+++ b/tests/dummy/app/pods/demo/controller.js
@@ -6,7 +6,7 @@ export default Ember.Controller.extend({
     let result = this.model.map((record) => {
       return {
         label: record.get('label'),
-        value: record.id
+        value: record.get('value')
       }
     })
     if (this.get('search')) {
@@ -20,6 +20,8 @@ export default Ember.Controller.extend({
 
   selectedIndex: 1,
   selectedIndices: [1, 2],
+  preSelectedValue: 'Arthur Curry',
+  selectedValues: ['Arthur Curry', 'Adam Meadows'],
 
   actions: {
     onChange (values) {

--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -20,7 +20,7 @@
   </div>
 
   <div class="example">
-    <div class="title">Pre-selected value</div>
+    <div class="title">Pre-selected index</div>
     <div class="snippet">
       {{format-markdown "```handlebars
 {{frost-select
@@ -36,6 +36,27 @@
         data=data
         on-change=(action 'onChange')
         selected=selectedIndex
+      }}
+    </div>
+  </div>
+
+  <div class="example">
+    <div class="title">Pre-selected value</div>
+    <div class="snippet">
+      {{format-markdown "```handlebars
+{{frost-select
+  data=data
+  on-change=(action 'onChange')
+  selectedValue=preSelectedValue
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-select
+        data=data
+        on-change=(action 'onChange')
+        selectedValue=preSelectedValue
       }}
     </div>
   </div>
@@ -129,7 +150,7 @@
   </div>
 
   <div class="example">
-    <div class="title">Multiple pre-selected values</div>
+    <div class="title">Multiple pre-selected indices</div>
     <div class="snippet">
       {{format-markdown "```handlebars
 {{frost-multi-select
@@ -145,6 +166,27 @@
         data=data
         on-change=(action 'onChange')
         selected=selectedIndices
+      }}
+    </div>
+  </div>
+
+  <div class="example">
+    <div class="title">Multiple pre-selected values</div>
+    <div class="snippet">
+      {{format-markdown "```handlebars
+{{frost-multi-select
+  data=data
+  on-change=(action 'onChange')
+  selectedValue=selectedValues
+}}
+```"
+      }}
+    </div>
+    <div class="demo">
+      {{frost-multi-select
+        data=data
+        on-change=(action 'onChange')
+        selectedValue=selectedValues
       }}
     </div>
   </div>

--- a/tests/integration/components/frost-multi-select-test.js
+++ b/tests/integration/components/frost-multi-select-test.js
@@ -170,6 +170,16 @@ describeComponent(
         })
       })
     })
+
+    it('keeps the list open when a value is selected', function (done) {
+      this.$('.down-arrow').click()
+      this.$('.frost-select li:first-child').click()
+      wait(() => {
+        const isOpen = this.$('.frost-select').hasClass('open')
+        expect(isOpen).to.be.true
+        done()
+      })
+    })
   }
 )
 


### PR DESCRIPTION
The `frost-select` component was throwing a runtime error if initialized with the "selectedValue" attribute, caused by an attempt to set the value of the search input before the search input existed.

Cases for programmatic selection by value have been added to the demo page.

#PATCH#