### PR TITLE
Covering case where selection is being unset externally.

### DIFF
--- a/addon/components/frost-multi-select.js
+++ b/addon/components/frost-multi-select.js
@@ -22,7 +22,7 @@ export default FrostSelect.extend({
   // ==========================================================================
 
   @readOnly
-  @computed('selected')
+  @computed('selectedIndices')
   /**
    * Calculate the prompt based on what is selected
    * @param {Number[]} selected - the currently selected indices
@@ -44,7 +44,7 @@ export default FrostSelect.extend({
   },
 
   @readOnly
-  @computed('selected')
+  @computed('selectedIndices')
   /**
    * Input should be disabled if anything is selected
    * @param {Number[]} selected - the selected indices
@@ -63,7 +63,7 @@ export default FrostSelect.extend({
    * @returns {String[]} the labels for all selected items
    */
   getLabels () {
-    return _.map(this.get('selected'), (selectedIndex) => {
+    return _.map(this.get('selectedIndices'), (selectedIndex) => {
       return this.get('data')[selectedIndex].label
     })
   },
@@ -73,14 +73,14 @@ export default FrostSelect.extend({
    * @param {Number} index - the index to select
    */
   select (index) {
-    const selected = this.get('selected')
+    const selected = this.get('selectedIndices')
 
     if (_.includes(selected, index)) {
       const newSelected = _.without(selected, index)
-      this.set('selected', newSelected)
+      this.set('selectedIndices', newSelected)
     } else {
       selected.push(index)
-      this.notifyPropertyChange('selected')
+      this.notifyPropertyChange('selectedIndices')
     }
 
     this.set('filter', undefined)
@@ -117,7 +117,7 @@ export default FrostSelect.extend({
       })
       .filter((val) => (val >= 0))
 
-    this.set('selected', selected)
+    this.set('selectedIndices', selected)
     this.set('filter', undefined)
     this.notifyOfChange(selected)
   },
@@ -141,7 +141,7 @@ export default FrostSelect.extend({
      */
     clearSelection () {
       const newSelection = []
-      this.set('selected', newSelection)
+      this.set('selectedIndices', newSelection)
       this.notifyOfChange(newSelection)
     }
   }

--- a/addon/components/frost-select.js
+++ b/addon/components/frost-select.js
@@ -60,7 +60,7 @@ export default Ember.Component.extend({
   // ==========================================================================
 
   @readOnly
-  @computed('items', 'selected', 'hovered', 'filter')
+  @computed('items', 'selectedIndices', 'hovered', 'filter')
   /**
    * Get the display items
    * @param {Object[]} items - the possible items
@@ -135,7 +135,7 @@ export default Ember.Component.extend({
   },
 
   @readOnly
-  @computed('selected')
+  @computed('selectedIndices')
   /**
    * Build the prompt based on the selected item(s)
    * @param {Number[]} selected - the selected indices
@@ -202,7 +202,7 @@ export default Ember.Component.extend({
     this._super(...arguments)
 
     if (this.get('selected') === undefined) {
-      this.set('selected', [])
+      this.set('selectedIndices', [])
     }
   },
 
@@ -222,7 +222,7 @@ export default Ember.Component.extend({
       let selected = this.get('selected')
 
       selected = selected && (_.isArray(selected) || _.isNumber(selected)) ? [].concat(selected) : []
-      this.set('selected', selected)
+      this.set('selectedIndices', selected)
     }
   },
 
@@ -265,7 +265,7 @@ export default Ember.Component.extend({
   },
 
   // TODO: add jsdoc
-  getValues (selected = this.get('selected')) {
+  getValues (selected = this.get('selectedIndices')) {
     return selected.map((selectedIndex) => {
       return this.get('data')[selectedIndex].value
     })
@@ -390,7 +390,7 @@ export default Ember.Component.extend({
   select (index) {
     let selected = index === null ? [] : [index]
     let values = this.getValues(selected)
-    this.set('selected', selected)
+    this.set('selectedIndices', selected)
 
     if (this.get('open')) {
       this.closeList()

--- a/addon/templates/components/frost-multi-select.hbs
+++ b/addon/templates/components/frost-multi-select.hbs
@@ -15,7 +15,7 @@
 </div>
 <div class="drop-down-container">
   <div class="multi-status">
-    <span class="number-selected">{{selected.length}} selected</span>
+    <span class="number-selected">{{selectedIndices.length}} selected</span>
     <span class="clear" tabIndex={-1} onClick={{action 'clearSelection'}}>Clear all</span>
   </div>
   <div class="list-container">


### PR DESCRIPTION
The `selected` state of was being unset by a consuming context. Slight refactor to separate the property from the actual internal state representation.
# PATCH
